### PR TITLE
Add support for feature types other than boolean

### DIFF
--- a/lib/src/uptech_growthbook_wrapper.dart
+++ b/lib/src/uptech_growthbook_wrapper.dart
@@ -25,7 +25,7 @@ class UptechGrowthBookWrapper {
   /// Initialize for use in app, seeds allow you to specify value of
   /// toggles prior to fetching remote toggle states. These will be
   /// the values if on init it fails to fetch the toggles from the remote.
-  void init({Map<String, bool>? seeds, Map<String, dynamic>? overrides}) {
+  void init({Map<String, dynamic>? seeds, Map<String, dynamic>? overrides}) {
     _overrides.clear();
     if (overrides != null) {
       _overrides.addAll(overrides);
@@ -35,7 +35,7 @@ class UptechGrowthBookWrapper {
 
   /// Initialize for use in automated test suite
   void initForTests(
-      {Map<String, bool>? seeds, Map<String, dynamic>? overrides}) {
+      {Map<String, dynamic>? seeds, Map<String, dynamic>? overrides}) {
     _overrides.clear();
     if (overrides != null) {
       _overrides.addAll(overrides);
@@ -60,8 +60,20 @@ class UptechGrowthBookWrapper {
     return _client.feature(featureId).on ?? false;
   }
 
+  /// Return the value of a feature.
+  /// If the feature does not have a value configured, returns null.
+  dynamic value(String featureId) {
+    final hasOverride = _overrides.containsKey(featureId);
+
+    if (hasOverride) {
+      return _overrides[featureId];
+    }
+
+    return _client.feature(featureId).value;
+  }
+
   GrowthBookSDK _createLiveClient(
-      {required String apiKey, required Map<String, bool>? seeds}) {
+      {required String apiKey, required Map<String, dynamic>? seeds}) {
     final gbContext = GBContext(
       apiKey: apiKey,
       enabled: true,
@@ -76,7 +88,7 @@ class UptechGrowthBookWrapper {
     );
   }
 
-  GrowthBookSDK _createTestClient({Map<String, bool>? seeds}) {
+  GrowthBookSDK _createTestClient({Map<String, dynamic>? seeds}) {
     final gbContext = GBContext(
       apiKey: 'some-garbage-key-because-we-are-not-using-it',
       hostURL: 'https://cdn.growthbook.io/',
@@ -89,7 +101,7 @@ class UptechGrowthBookWrapper {
     );
   }
 
-  Map<String, GBFeature> _seedsToGBFeatures({Map<String, bool>? seeds}) {
+  Map<String, GBFeature> _seedsToGBFeatures({Map<String, dynamic>? seeds}) {
     if (seeds != null) {
       return seeds
           .map((key, value) => MapEntry(key, GBFeature(defaultValue: value)));

--- a/lib/src/uptech_growthbook_wrapper_test_client.dart
+++ b/lib/src/uptech_growthbook_wrapper_test_client.dart
@@ -5,7 +5,7 @@ import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 class UptechGrowthBookWrapperTestClient extends BaseClient {
   UptechGrowthBookWrapperTestClient({this.seeds});
 
-  final Map<String, bool>? seeds;
+  final Map<String, dynamic>? seeds;
 
   @override
   consumeGetRequest(String path, OnSuccess onSuccess, OnError onError) async {
@@ -17,7 +17,7 @@ class UptechGrowthBookWrapperTestClient extends BaseClient {
     onSuccess(data);
   }
 
-  Map<String, dynamic> _seedsToHashFeatures(Map<String, bool>? seeds) {
+  Map<String, dynamic> _seedsToHashFeatures(Map<String, dynamic>? seeds) {
     final Map<String, dynamic> emptyFeatures = {};
     if (seeds != null) {
       return seeds.map((key, value) => MapEntry(key, {'defaultValue': value}));

--- a/test/uptech_growthbook_sdk_flutter_test.dart
+++ b/test/uptech_growthbook_sdk_flutter_test.dart
@@ -48,6 +48,49 @@ void main() {
         });
       });
     });
+
+    group('#value', () {
+      const String stringValue = 'string-value';
+      const String intValue = 'int-value';
+
+      group('when no value is found for the feature', () {
+        setUp(() {
+          ToglTest.instance.initForTests(
+              seeds: {stringValue: 'value', intValue: 1, featureName: true});
+        });
+
+        test('it returns null', () {
+          expect(ToglTest.instance.value('some-other-feature'), isNull);
+        });
+      });
+
+      group('when a feature value is present', () {
+        setUp(() {
+          ToglTest.instance.initForTests(
+              seeds: {stringValue: 'value', intValue: 1, featureName: true});
+        });
+
+        test('it returns the feature value', () {
+          expect(ToglTest.instance.value(stringValue), equals('value'));
+          expect(ToglTest.instance.value(intValue), equals(1));
+          expect(ToglTest.instance.value(featureName), isTrue);
+        });
+      });
+
+      group('when an override is present', () {
+        setUp(() {
+          ToglTest.instance.initForTests(
+            overrides: {stringValue: 'value', intValue: 1, featureName: true},
+          );
+        });
+
+        test('it returns the overridden value', () {
+          expect(ToglTest.instance.value(stringValue), equals('value'));
+          expect(ToglTest.instance.value(intValue), equals(1));
+          expect(ToglTest.instance.value(featureName), isTrue);
+        });
+      });
+    });
   });
 
   group('loadOverridesFromAssets', () {


### PR DESCRIPTION
The intention is to support the other data types a feature can be.
These include String, int, or a json data object.

The reason for this is to allow for more flexibility in the types of
features we support. Specifically, I wanted to support String and int
types so we could use this to manage more configuration type things rather
than strictly using this for boolean feature toggles.

[changelog]
added: Support for non-boolean features

ps-id: 9cf32380-e5c7-45d5-a598-bf21b1dc3af2