### PR TITLE
[UE-2] Add rules parameter to test client

### DIFF
--- a/lib/src/uptech_growthbook_wrapper.dart
+++ b/lib/src/uptech_growthbook_wrapper.dart
@@ -35,12 +35,14 @@ class UptechGrowthBookWrapper {
 
   /// Initialize for use in automated test suite
   void initForTests(
-      {Map<String, bool>? seeds, Map<String, dynamic>? overrides}) {
+      {Map<String, bool>? seeds,
+      Map<String, dynamic>? overrides,
+      List<Map<String, dynamic>>? rules}) {
     _overrides.clear();
     if (overrides != null) {
       _overrides.addAll(overrides);
     }
-    _client = _createTestClient(seeds: seeds);
+    _client = _createTestClient(seeds: seeds, rules: rules);
   }
 
   /// Force a refresh of toggles from the server
@@ -60,8 +62,10 @@ class UptechGrowthBookWrapper {
     return _client.feature(featureId).on ?? false;
   }
 
-  GrowthBookSDK _createLiveClient(
-      {required String apiKey, required Map<String, bool>? seeds}) {
+  GrowthBookSDK _createLiveClient({
+    required String apiKey,
+    required Map<String, bool>? seeds,
+  }) {
     final gbContext = GBContext(
       apiKey: apiKey,
       enabled: true,
@@ -76,7 +80,8 @@ class UptechGrowthBookWrapper {
     );
   }
 
-  GrowthBookSDK _createTestClient({Map<String, bool>? seeds}) {
+  GrowthBookSDK _createTestClient(
+      {Map<String, bool>? seeds, List<Map<String, dynamic>>? rules}) {
     final gbContext = GBContext(
       apiKey: 'some-garbage-key-because-we-are-not-using-it',
       hostURL: 'https://cdn.growthbook.io/',
@@ -84,7 +89,7 @@ class UptechGrowthBookWrapper {
     );
     return GrowthBookSDK(
       context: gbContext,
-      client: UptechGrowthBookWrapperTestClient(seeds: seeds),
+      client: UptechGrowthBookWrapperTestClient(seeds: seeds, rules: rules),
       features: _seedsToGBFeatures(seeds: seeds),
     );
   }

--- a/lib/src/uptech_growthbook_wrapper_test_client.dart
+++ b/lib/src/uptech_growthbook_wrapper_test_client.dart
@@ -3,24 +3,28 @@ import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 /// A client to be stubbed into GrowthBookSDK to return explicitly
 /// configured toggle states for automated tests.
 class UptechGrowthBookWrapperTestClient extends BaseClient {
-  UptechGrowthBookWrapperTestClient({this.seeds});
+  UptechGrowthBookWrapperTestClient({this.seeds, this.rules});
 
   final Map<String, bool>? seeds;
+  final List<Map<String, dynamic>>? rules;
 
   @override
   consumeGetRequest(String path, OnSuccess onSuccess, OnError onError) async {
     final Map<String, dynamic> data = {
       'status': 200,
-      'features': _seedsToHashFeatures(seeds),
+      'features': _seedsToHashFeatures(seeds, rules),
       'dateUpdated': DateTime.now(),
     };
     onSuccess(data);
   }
 
-  Map<String, dynamic> _seedsToHashFeatures(Map<String, bool>? seeds) {
+  Map<String, dynamic> _seedsToHashFeatures(
+      Map<String, bool>? seeds, List<Map<String, dynamic>>? rules) {
     final Map<String, dynamic> emptyFeatures = {};
     if (seeds != null) {
-      return seeds.map((key, value) => MapEntry(key, {'defaultValue': value}));
+      return seeds.map((key, value) {
+        return MapEntry(key, {'defaultValue': value, 'rules': rules ?? []});
+      });
     } else {
       return emptyFeatures;
     }


### PR DESCRIPTION
The reason for this change is to be able to test the attributes 
feature using our test client. This allows us to eventually pass
app given attributes to the SDK and compare them to rules set 
in the SDK to turn a feature on or off. Using this feature, users 
of a package can select specific user ids to canary test the app 
before releasing to the public. Previously, the test client did not 
have the ability to have rules associated with a feature, which 
is present in the Growthbook SDK client.

To achieve this, an optional rules parameter has been added 
to the test client class and the rules key has been added to 
the mapping function on the class.

The optional rules parameter has also been added to the test init 
function in the wrapper so that it can pass the necessary rules 
to the client.

For example, if the following rules argument is passed to the test 
init function:
```
[
    {
      'condition': {
        'version': {'$gt': '1.0.0'}
      },
      'force': true
    }
];
```
The test client will be able to check for a 'version' attribute and 
toggle the feature on or off based on the attribute's value (will 
toggle on if the value is greater than 1.0.0.

[changelog]
added: rule parameter to the test client and the test init method

ps-id: E724A507-B0ED-43CA-823D-DFC73BB4899E