### PR TITLE
[UE-2] Add attributes parameter to init

### DIFF
--- a/lib/src/uptech_growthbook_wrapper.dart
+++ b/lib/src/uptech_growthbook_wrapper.dart
@@ -21,14 +21,22 @@ class UptechGrowthBookWrapper {
   late GrowthBookSDK _client;
   final String apiKey;
   final Map<String, dynamic> _overrides = {};
+  final Map<String, dynamic> _attributes = {};
 
   /// Initialize for use in app, seeds allow you to specify value of
   /// toggles prior to fetching remote toggle states. These will be
   /// the values if on init it fails to fetch the toggles from the remote.
-  void init({Map<String, bool>? seeds, Map<String, dynamic>? overrides}) {
+  void init(
+      {Map<String, bool>? seeds,
+      Map<String, dynamic>? overrides,
+      Map<String, dynamic>? attributes}) {
     _overrides.clear();
+    _attributes.clear();
     if (overrides != null) {
       _overrides.addAll(overrides);
+    }
+    if (attributes != null) {
+      _attributes.addAll(attributes);
     }
     _client = _createLiveClient(apiKey: apiKey, seeds: seeds);
   }
@@ -37,10 +45,15 @@ class UptechGrowthBookWrapper {
   void initForTests(
       {Map<String, bool>? seeds,
       Map<String, dynamic>? overrides,
+      Map<String, dynamic>? attributes,
       List<Map<String, dynamic>>? rules}) {
     _overrides.clear();
+    _attributes.clear();
     if (overrides != null) {
       _overrides.addAll(overrides);
+    }
+    if (attributes != null) {
+      _attributes.addAll(attributes);
     }
     _client = _createTestClient(seeds: seeds, rules: rules);
   }
@@ -70,6 +83,7 @@ class UptechGrowthBookWrapper {
       apiKey: apiKey,
       enabled: true,
       qaMode: false,
+      attributes: _attributes,
       hostURL: 'https://cdn.growthbook.io/',
       forcedVariation: <String, int>{},
       trackingCallBack: (gbExperiment, gbExperimentResult) {},
@@ -85,6 +99,7 @@ class UptechGrowthBookWrapper {
     final gbContext = GBContext(
       apiKey: 'some-garbage-key-because-we-are-not-using-it',
       hostURL: 'https://cdn.growthbook.io/',
+      attributes: _attributes,
       trackingCallBack: (gbExperiment, gbExperimentResult) {},
     );
     return GrowthBookSDK(

--- a/test/uptech_growthbook_sdk_flutter_test.dart
+++ b/test/uptech_growthbook_sdk_flutter_test.dart
@@ -47,6 +47,54 @@ void main() {
           expect(ToglTest.instance.isOn(featureName), isTrue);
         });
       });
+
+      group('when the attribute meets the condition', () {
+        setUp(() {
+          const String greaterThan = '\$gt';
+          ToglTest.instance.initForTests(
+            seeds: {
+              featureName: false,
+            },
+            rules: [
+              {
+                'condition': {
+                  'version': {greaterThan: '1.0.0'}
+                },
+                'force': true
+              }
+            ],
+            attributes: {'version': '1.0.1'},
+          );
+        });
+
+        test('it returns true', () {
+          expect(ToglTest.instance.isOn(featureName), isTrue);
+        });
+      });
+
+      group('when the attribute does not meet the condition', () {
+        setUp(() {
+          const String greaterThan = '\$gt';
+          ToglTest.instance.initForTests(
+            seeds: {
+              featureName: false,
+            },
+            rules: [
+              {
+                'condition': {
+                  'version': {greaterThan: '1.0.0'}
+                },
+                'force': true
+              }
+            ],
+            attributes: {'version': '0.0.9'},
+          );
+        });
+
+        test('it returns false', () {
+          expect(ToglTest.instance.isOn(featureName), isFalse);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
The intention for this change is to be able to add attributes from the app (userId, version number, etc) to GrowthBook and either show or hide a feature based on that feature's rules. The reason for adding attributes is to allow for canary testing or limiting features to specific versions of an app. This happens on initialization as that is the way to send attributes to the SDK in flutter.

To achieve this, an optional attributes parameter has been added to the init and test init classes. The attributes are saved to a value on the class and used in the create client methods when creating the context. Tests for this functionality use a version number attribute to test against rules that dictate the app should be a certain version or higher to use the mock feature

[changelog]
added: attribute parameter to the init methods

ps-id: 6DDF347D-6BAB-4D7B-A31B-AD0B0D421338