### PR TITLE
[UE-3] Change apiKey to accept full url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ way you want. You need to get the read-only API key for each of the
 environments and configure them in your app per environment.
 
 Then you need to setup a singleton in your app to to house the shared instance
-of the `UptechGrowthBookWrapper`. *Note:* This is whan needs the `apiKey` that
+of the `UptechGrowthBookWrapper`. *Note:* This is whan needs the `apiKeyUrl` that
 should come from your environment config and **not** be hard coded in your app.
 This might look as follows maybe in a file called, `lib/togls.dart`. It is
 really up to you how you do this. This is just a suggestion.
@@ -38,8 +38,8 @@ class Togls extends UptechGrowthBookWrapper {
   Togls()
       : super(
           // In GrowthBook dashboard > SDK Endpoints url: https://cdn.growthbook.io/api/features/dev_Y1WwxOm9sDnIsO1DLvwJk76z3ribr3VoiTsaOs?project=prj_29g61lbb6s8290
-          // Include everything after the last '/'. example: dev_Y1WwxOm9sDnIsO1DLvwJk76z3ribr3VoiTsaOs?project=prj_29g61lbb6s8290
-          apiKey: 'your-api-key', 
+          // Include the entire url above
+          apiKey: 'your-api-key-url', 
         );
 
   static final shared = Togls();

--- a/lib/src/uptech_growthbook_wrapper.dart
+++ b/lib/src/uptech_growthbook_wrapper.dart
@@ -16,10 +16,10 @@ Future<Map<String, dynamic>> loadOverridesFromAssets(String assetsPath) async {
 /// live client and stubbed out client for use case in
 /// automated testing.
 class UptechGrowthBookWrapper {
-  UptechGrowthBookWrapper({required this.apiKey});
+  UptechGrowthBookWrapper({required this.apiKeyUrl});
 
   late GrowthBookSDK _client;
-  final String apiKey;
+  final String apiKeyUrl;
   final Map<String, dynamic> _overrides = {};
   final Map<String, dynamic> _attributes = {};
 
@@ -38,7 +38,7 @@ class UptechGrowthBookWrapper {
     if (attributes != null) {
       _attributes.addAll(attributes);
     }
-    _client = _createLiveClient(apiKey: apiKey, seeds: seeds);
+    _client = _createLiveClient(apiKeyUrl: apiKeyUrl, seeds: seeds);
   }
 
   /// Initialize for use in automated test suite
@@ -88,15 +88,18 @@ class UptechGrowthBookWrapper {
   }
 
   GrowthBookSDK _createLiveClient({
-    required String apiKey,
+    required String apiKeyUrl,
     required Map<String, dynamic>? seeds,
   }) {
+    final dividingIndex = apiKeyUrl.lastIndexOf('/');
+    final apiKey = apiKeyUrl.substring(dividingIndex + 1);
+    final hostURL = apiKeyUrl.substring(0, dividingIndex);
     final gbContext = GBContext(
       apiKey: apiKey,
       enabled: true,
       qaMode: false,
       attributes: _attributes,
-      hostURL: 'https://cdn.growthbook.io/',
+      hostURL: hostURL,
       forcedVariation: <String, int>{},
       trackingCallBack: (gbExperiment, gbExperimentResult) {},
     );

--- a/test/uptech_growthbook_sdk_flutter_test.dart
+++ b/test/uptech_growthbook_sdk_flutter_test.dart
@@ -3,7 +3,9 @@ import 'package:uptech_growthbook_sdk_flutter/uptech_growthbook_sdk_flutter.dart
 import 'package:flutter_test/flutter_test.dart';
 
 class ToglTest extends UptechGrowthBookWrapper {
-  ToglTest() : super(apiKey: 'dummy-api-key');
+  ToglTest()
+      : super(
+            apiKeyUrl: 'https://cdn.growthbook.io/api/features/dummy-api-key');
 
   static ToglTest instance = ToglTest();
 }


### PR DESCRIPTION
The intention for this change is for users of this package to add their auth details in a more intuitive way. It has been proven that users instinctively use the full cdn url with the api key in the apiKey, resulting in an error.

The argument is renamed to apiKeyUrl to be clear about what should be inputted as an argument. The url is put through a method that removes the url portion of the string, leaving only the api key to be used in the `GBContext`. The README is also updated to reflect these changes and instructs to use the full url found on the GrowthBook dashboard.

[changelog]
changed: required key for UptechGrowthBookWrapper

ps-id: A7F6E07A-23EB-4EF3-B45E-DA8567C78614