### PR TITLE
[UE-15] Add set attribute method

### DIFF
--- a/lib/src/uptech_growthbook_wrapper.dart
+++ b/lib/src/uptech_growthbook_wrapper.dart
@@ -63,6 +63,14 @@ class UptechGrowthBookWrapper {
     return await _client.refresh();
   }
 
+  void setAttributes(Map<String, dynamic> attributes) {
+    if (_client.context.attributes != null) {
+      _client.context.attributes?.addEntries(attributes.entries);
+    } else {
+      _client.context.attributes = attributes;
+    }
+  }
+
   /// Check if a feature is on/off
   bool isOn(String featureId) {
     final hasOverride = _overrides.containsKey(featureId);

--- a/test/uptech_growthbook_sdk_flutter_test.dart
+++ b/test/uptech_growthbook_sdk_flutter_test.dart
@@ -102,26 +102,51 @@ void main() {
       });
 
       group('when the attribute meets the condition', () {
-        setUp(() {
-          const String greaterThan = '\$gt';
-          ToglTest.instance.initForTests(
-            seeds: {
-              'some-feature': false,
-            },
-            rules: [
-              {
-                'condition': {
-                  'version': {greaterThan: '1.0.0'}
-                },
-                'force': true
-              }
-            ],
-            attributes: {'version': '1.0.1'},
-          );
-        });
+        group('and the attribute is added on init', () {
+          setUp(() {
+            const String greaterThan = '\$gt';
+            ToglTest.instance.initForTests(
+              seeds: {
+                'some-feature': false,
+              },
+              rules: [
+                {
+                  'condition': {
+                    'version': {greaterThan: '1.0.0'}
+                  },
+                  'force': true
+                }
+              ],
+              attributes: {'version': '1.0.1'},
+            );
+          });
 
-        test('it returns true', () {
-          expect(ToglTest.instance.isOn('some-feature'), isTrue);
+          test('it returns true', () {
+            expect(ToglTest.instance.isOn('some-feature'), isTrue);
+          });
+        });
+        group('and the attribute is added asynchronously', () {
+          setUp(() {
+            const String greaterThan = '\$gt';
+            ToglTest.instance.initForTests(
+              seeds: {
+                'some-feature': false,
+              },
+              rules: [
+                {
+                  'condition': {
+                    'version': {greaterThan: '1.0.0'}
+                  },
+                  'force': true
+                }
+              ],
+            );
+            ToglTest.instance.setAttributes({'version': '1.0.1'});
+          });
+
+          test('it returns true', () {
+            expect(ToglTest.instance.isOn('some-feature'), isTrue);
+          });
         });
       });
 


### PR DESCRIPTION
The intention for this change is to give users the ability to add attributes after the wrapper has been initialized. This is helpful in insteances where required attributes cannot be acquired until long after an app is initialized. For instance, with canary testing a feature will only be available to select users. The user's id cannot be determined until after they have logged in.

To achieve this, a new public method has been added to the wrapper that takes in an attributes parameter. If the client already has attributes (ie they were added during init), the new attributes are added alongside the old attributes. Otherwise, the new attributes are assigned to the attributes key in the client's context.

[changelog]
added: public set attribute method

ps-id: 8E6ED4DD-BB8E-4C27-85E3-4D1F85DF0667