### PR TITLE
[UE-22] Document setting attributes at initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,28 @@ launched the app and the network connection is not working or the GrowthBook
 service was down then the toggles would evaluate to the value specified in the
 `seeds`.
 
+### Adding attributes
+
+If you want to add attributes at itialization, you can add values into the `attributes` key in the init function. This is useful if, for instance, you are only allowing certain versions of your app to access a feature.
+```dart
+void main() async {
+	// ...
+	// ...
+	WidgetsFlutterBinding.ensureInitialized();
+	final overrides = await loadOverridesFromAssets('assets/overrides.json');
+  final version = getVersionNumber(); // this is a method you create and provide the logic for
+	Togls.shared.init(
+		seeds: {
+		  'example-toggle-higher-fee': false,
+		},
+		overrides: overrides,
+    attributes: attributes: {'version': version},
+	);
+	// ...
+	// ...
+}
+```
+
 ## Usage
 
 Once you have it setup you are ready to start using it. The following examples


### PR DESCRIPTION
The reason for this change is to give users of this package instruction on how to add attributes on
init, as well as an explanation on why they may want to do so. The example shows how they might add a
version attribute on init.

Please note that there are no instructions on adding the versioning rule in Growthbook or how to get an app's version number, as this is out of scope for the package.

[changelog]
added: 'Set attribute on init' section in README

ps-id: D6F4ADEF-5AEC-42AF-9F63-587DEBD716E4