### PR TITLE
[UE-23] Document updating attributes after initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ int sampleApplyFee(int amount) {
 }
 ```
 
+### Set attributes
+Additional attributes can be set after initialization. This is a common use case in which an id attribute is set after user login (useful for canary testing). 
+```dart
+import 'package:yourproject/togls.dart';
+
+int sampleLogIn() {
+  final userId = await login(); // Fake method that logs in user and gets user id
+  Togls.shared.setAttributes({'id': userId});
+}
+```
+
 ### Control toggles in automated tests
 
 ```dart


### PR DESCRIPTION
The reason for this change is to give users of this package instruction on how to use the setAttribute method. The example shows how they might add a user id attribute in their login logic.

Please note that there are no instructions on adding the users for canary testing within the Growthbook GUI or fetching the user id after log in, as this is out of scope for the package.

[changelog]
added: 'Set attribute' section in README

ps-id: 02055CF4-24C4-4AEC-A3C7-C9C59CDCC64E