### PR TITLE
[UE-20] Document non-boolean toggle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ int sampleApplyFee(int amount) {
 }
 ```
 
+### Evaluate Feature value
+
+```dart
+import 'package:yourproject/togls.dart';
+
+int sampleApplyFee(int amount) {
+  // Note: feature value can be of any type
+  final featureValue = Togls.shared.value('example-toggle-higher-fee');
+  if (featureValue != 0) {
+    return amount + 20;
+  } else {
+    return amount + 10;
+  }
+}
+```
+
 ### Set attributes
 Additional attributes can be set after initialization. This is a common use case in which an id attribute is set after user login (useful for canary testing). 
 ```dart


### PR DESCRIPTION
The reason for this change is to give users of this package instruction on how to use the value method. The
example shows how they might get a feature's value (in this case an int) and use it to determine some business logic.

[changelog]
added: 'Evaluate Feature value' section in README

ps-id: 1A743160-40E2-4E30-976C-CA4D31C1B55B