### PR TITLE
Update the version range of sdk compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.0
 homepage: https://github.com/uptech/uptech-growthbook-sdk-flutter
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: ">=2.17.2 <4.0.0"
   flutter: '>=1.17.0'
 
 dependencies:


### PR DESCRIPTION
This matches the sdk versioning in the GrowthBook SDK Flutter library, and increases the supported sdk version from `<3.0.0` to `<4.0.0`.

[changelog]
updated: increased supported sdk versioning from `>=2.18.1 <3.0.0` to `>=2.17.2 <4.0.0` to match the underlying GrowthBook SDK Flutter library

<!-- ps-id: 85d026e0-f8ae-4240-bac9-cfd80010f3b8 -->