### PR TITLE
Pin Version 3.0.0 of Growthbook

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  growthbook_sdk_flutter: ^3.0.0+0
+  growthbook_sdk_flutter: 3.0.0+0
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
Some of the later versions of Growthbook introduced breaking changes. This pins version 3.0.0+0 as the version to use in this package.

[changelog]
changed: Changed the reference version of Growthbook and forced it to 3.0.0 as new versions introduced breaking changes for web

<!-- ps-id: 4b669548-5c31-4d5e-beaf-fc1006c917c9 -->